### PR TITLE
Fix missing package info

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,5 +1,5 @@
 import PackageDescription
 
 let package = Package(
-    name: "swift-libmysql"
+    name: "CMySQLClient"
 )

--- a/Package.swift
+++ b/Package.swift
@@ -1,1 +1,5 @@
+import PackageDescription
 
+let package = Package(
+    name: "swift-libmysql"
+)


### PR DESCRIPTION
Swift 3 requires a valid Package in the Package.swift file.
